### PR TITLE
feat: 작성 화면 image delete 기능 구현

### DIFF
--- a/ios-tripbook/Model/TravelNewsModel.swift
+++ b/ios-tripbook/Model/TravelNewsModel.swift
@@ -18,6 +18,7 @@ struct TravelNewsModel: Identifiable {
     /// 제목
     let title: String
     /// 썸네일 이미지
+    let thumbnailId: Int?
     let thumbnailURL: URL?
     let location: LocationInfo?
     /// 좋아요 수
@@ -34,6 +35,7 @@ struct TravelNewsModel: Identifiable {
         author: Author,
         content: String,
         title: String,
+        thumbnailId: Int?,
         thumbnailURL: String?,
         location: LocationInfo?,
         likeCount: Int,
@@ -44,6 +46,7 @@ struct TravelNewsModel: Identifiable {
         self.author = author
         self.content = content
         self.title = title
+        self.thumbnailId = thumbnailId
         if let thumbnailURL = thumbnailURL {
             self.thumbnailURL = URL(string: thumbnailURL)
         } else {
@@ -65,7 +68,8 @@ struct TravelNewsModel: Identifiable {
                 role: ""
             ),
             content: "xxxx",
-            title: "뚜벅이가 여행하기 좋은 장소 Top 5",
+            title: "뚜벅이가 여행하기 좋은 장소 Top 5", 
+            thumbnailId: nil,
             thumbnailURL: "https://tripbook-bucket.s3.ap-northeast-2.amazonaws.com/member/profile/51fa4c27-0a0a-4c69-ba79-7ff1b8eaef358964%20bytes.jpeg",
             location: nil,
             likeCount: 3,

--- a/ios-tripbook/Model/TravelNewsModel.swift
+++ b/ios-tripbook/Model/TravelNewsModel.swift
@@ -18,7 +18,6 @@ struct TravelNewsModel: Identifiable {
     /// 제목
     let title: String
     /// 썸네일 이미지
-    let thumbnailId: Int?
     let thumbnailURL: URL?
     let location: LocationInfo?
     /// 좋아요 수
@@ -35,7 +34,6 @@ struct TravelNewsModel: Identifiable {
         author: Author,
         content: String,
         title: String,
-        thumbnailId: Int?,
         thumbnailURL: String?,
         location: LocationInfo?,
         likeCount: Int,
@@ -46,7 +44,6 @@ struct TravelNewsModel: Identifiable {
         self.author = author
         self.content = content
         self.title = title
-        self.thumbnailId = thumbnailId
         if let thumbnailURL = thumbnailURL {
             self.thumbnailURL = URL(string: thumbnailURL)
         } else {
@@ -69,7 +66,6 @@ struct TravelNewsModel: Identifiable {
             ),
             content: "xxxx",
             title: "뚜벅이가 여행하기 좋은 장소 Top 5", 
-            thumbnailId: nil,
             thumbnailURL: "https://tripbook-bucket.s3.ap-northeast-2.amazonaws.com/member/profile/51fa4c27-0a0a-4c69-ba79-7ff1b8eaef358964%20bytes.jpeg",
             location: nil,
             likeCount: 3,

--- a/ios-tripbook/Network/API/Common/TBCommonAPI.swift
+++ b/ios-tripbook/Network/API/Common/TBCommonAPI.swift
@@ -25,5 +25,15 @@ struct TBCommonAPI: APIable {
             uploadImages: ["image": [image]]
         )
     }
+    
+    static func delete(imageIds: [Int]) -> Self {
+        return TBCommonAPI(
+            path: TBAPIPath.Common.imageDelete,
+            method: .post,
+            parameters: ["fileIds": imageIds],
+            headers: .init(),
+            uploadImages: [:]
+        )
+    }
 }
 

--- a/ios-tripbook/Network/API/TravelNews/Model/SearchResponse.swift
+++ b/ios-tripbook/Network/API/TravelNews/Model/SearchResponse.swift
@@ -28,6 +28,7 @@ struct ContentResponse: Decodable {
     let title: String
     let content: String
     let author: AuthorResponse
+    let thumbnailId: Int?
     let thumbnailUrl: String?
     let tagList: [String]?
     let heartNum: Int
@@ -44,7 +45,8 @@ struct ContentResponse: Decodable {
             id: id,
             author: author.toDomain,
             content: content,
-            title: title,
+            title: title, 
+            thumbnailId: thumbnailId,
             thumbnailURL: thumbnailUrl,
             location: self.location?.first?.toDomain,
             likeCount: heartNum,

--- a/ios-tripbook/Network/API/TravelNews/Model/SearchResponse.swift
+++ b/ios-tripbook/Network/API/TravelNews/Model/SearchResponse.swift
@@ -28,7 +28,6 @@ struct ContentResponse: Decodable {
     let title: String
     let content: String
     let author: AuthorResponse
-    let thumbnailId: Int?
     let thumbnailUrl: String?
     let tagList: [String]?
     let heartNum: Int
@@ -46,7 +45,6 @@ struct ContentResponse: Decodable {
             author: author.toDomain,
             content: content,
             title: title, 
-            thumbnailId: thumbnailId,
             thumbnailURL: thumbnailUrl,
             location: self.location?.first?.toDomain,
             likeCount: heartNum,

--- a/ios-tripbook/Network/Base/Path/TBCommonAPIPath.swift
+++ b/ios-tripbook/Network/Base/Path/TBCommonAPIPath.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct TBCommonAPIPath {
     let imageUpload = "/common/image/upload"
+    let imageDelete = "/common/image/delete"
 }

--- a/ios-tripbook/Util/Extension/NSAttributedString+Extension.swift
+++ b/ios-tripbook/Util/Extension/NSAttributedString+Extension.swift
@@ -8,8 +8,9 @@
 import Foundation
 
 extension NSAttributedString {
-    func toImageTag(dic: [Int: String]) -> [String] {
+    func toImageTag(dic: [Int: String]) -> ([String], Set<Int>) {
         var arr: [String] = []
+        var usedIds: Set<Int> = []
         self.enumerateAttribute(
             .init("ID"),
             in: NSRange(location: 0, length: self.length), options: []
@@ -17,10 +18,11 @@ extension NSAttributedString {
             if let id = value as? Int {
                 if let urlString = dic[id] {
                     arr.append("<img id=\(id) style=\"border-radius:12.56px;\" src=\"\(urlString)\" width=\"335\">")
+                    usedIds.insert(id)
                 }
             }
         }
-        return arr
+        return (arr, usedIds)
     }
     
     func toHTML() -> String? {

--- a/ios-tripbook/View/TravelNews/Register/RegisterTravelNewsEditerView.swift
+++ b/ios-tripbook/View/TravelNews/Register/RegisterTravelNewsEditerView.swift
@@ -161,9 +161,7 @@ class RegisterTravelReportVC: UIViewController, UINavigationControllerDelegate {
                         self.photoImageView.isHidden = true
                         self.photoLabel.isHidden = true
                         Task {
-                            if self.viewModel.thumbnailId != nil {
-                                await self.viewModel.deleteThumbnailImage()
-                            }
+                            await self.viewModel.deleteThumbnailImage()
                             let imageData = selectedImage.jpegData(compressionQuality: 1.0)
                             let (imageURL, id) = await self.viewModel.setImage(imageData!, imageType: .thumbnail)
                             self.viewModel.thumbnail = imageURL
@@ -255,6 +253,7 @@ class RegisterTravelReportVC: UIViewController, UINavigationControllerDelegate {
     @objc
     func tapDraftButton(_ sender: UIButton) {
         postSave(.temp)
+        viewModel.thumbnailId = nil
     }
     
     private func makeHeaderView() {
@@ -996,7 +995,6 @@ extension RegisterTravelReportVC {
                 guard let temp = temp else { return }
                 self.coverImageView.kf.setImage(with: temp.thumbnailURL)
                 if temp.thumbnailURL != nil {
-                    self.viewModel.thumbnailId = temp.thumbnailId
                     self.viewModel.thumbnail = temp.thumbnailURL?.absoluteString
                     self.photoImageView.isHidden = true
                     self.photoLabel.isHidden = true

--- a/ios-tripbook/View/TravelNews/Register/RegisterTravelNewsEditerView.swift
+++ b/ios-tripbook/View/TravelNews/Register/RegisterTravelNewsEditerView.swift
@@ -160,9 +160,13 @@ class RegisterTravelReportVC: UIViewController, UINavigationControllerDelegate {
                         self.photoImageView.isHidden = true
                         self.photoLabel.isHidden = true
                         Task {
+                            if self.viewModel.thumbnailId != nil {
+                                await self.viewModel.deleteThumbnailImage()
+                            }
                             let imageData = selectedImage.jpegData(compressionQuality: 1.0)
-                            let imageURL = await self.viewModel.setImage(imageData!)
-                            self.viewModel.thumbnail = imageURL.0
+                            let (imageURL, id) = await self.viewModel.setImage(imageData!, imageType: .thumbnail)
+                            self.viewModel.thumbnail = imageURL
+                            self.viewModel.thumbnailId = id
                         }
                     }
                 }
@@ -988,9 +992,13 @@ extension RegisterTravelReportVC {
                 guard let temp = temp else { return }
                 self.coverImageView.kf.setImage(with: temp.thumbnailURL)
                 if temp.thumbnailURL != nil {
+                    self.viewModel.thumbnailId = temp.thumbnailId
+                    self.viewModel.thumbnail = temp.thumbnailURL?.absoluteString
                     self.photoImageView.isHidden = true
                     self.photoLabel.isHidden = true
                 } else {
+                    self.viewModel.thumbnailId = nil
+                    self.viewModel.thumbnail = nil
                     self.photoImageView.isHidden = false
                     self.photoLabel.isHidden = false
                 }


### PR DESCRIPTION
구현 내용
- 사용하지 않는 이미지 서버에서 삭제되도록 api 연동 및 기능 구현
- 등록 및 임시저장에 저장된 이미지는 삭제되지 않도록 구현

개선이 필요한 부분
사용자가 글쓰기 화면에서 앱을 강제 종료할 경우 해당 글에 등록한 이미지가 삭제되지 않는 문제가 있음